### PR TITLE
Although RFC 9111 does not explicitly define this, in general cacheable methods are GET and HEAD, so the default should be GET and HEAD.

### DIFF
--- a/rfc9111/default.go
+++ b/rfc9111/default.go
@@ -3,15 +3,16 @@ package rfc9111
 import "net/http"
 
 var defaultUnderstoodMethods = []string{
+	// Although RFC 9111 does not explicitly define this, in general cacheable methods are GET and HEAD, so the default should be GET and HEAD.
 	http.MethodGet,
 	http.MethodHead,
-	http.MethodPost,
-	http.MethodPut,
-	http.MethodPatch,
-	http.MethodDelete,
-	http.MethodConnect,
-	http.MethodOptions,
-	http.MethodTrace,
+	// http.MethodPost,
+	// http.MethodPut,
+	// http.MethodPatch,
+	// http.MethodDelete,
+	// http.MethodConnect,
+	// http.MethodOptions,
+	// http.MethodTrace,
 }
 
 var defaultUnderstoodStatusCodes = []int{

--- a/rfc9111/shared_test.go
+++ b/rfc9111/shared_test.go
@@ -204,7 +204,7 @@ func TestShared_Storable(t *testing.T) {
 			time.Time{},
 		},
 		{
-			"GET 500 Cache-Control: public, Last-Modified 2024-12-13 14:15:06 -> +1s",
+			"GET 200 Cache-Control: public, Last-Modified 2024-12-13 14:15:06 -> +1s",
 			&http.Request{
 				Method: http.MethodGet,
 			},
@@ -219,7 +219,22 @@ func TestShared_Storable(t *testing.T) {
 			time.Date(2024, 12, 13, 14, 15, 17, 00, time.UTC),
 		},
 		{
-			"GET 500 Cache-Control: public -> No Store",
+			"POST 201 Cache-Control: public, Last-Modified 2024-12-13 14:15:06 -> No Store",
+			&http.Request{
+				Method: http.MethodPost,
+			},
+			&http.Response{
+				StatusCode: http.StatusCreated,
+				Header: http.Header{
+					"Last-Modified": []string{"Mon, 13 Dec 2024 14:15:06 GMT"},
+					"Cache-Control": []string{"public"},
+				},
+			},
+			false,
+			time.Time{},
+		},
+		{
+			"GET 200 Cache-Control: public (only) -> No Store",
 			&http.Request{
 				Method: http.MethodGet,
 			},


### PR DESCRIPTION
SSIA.